### PR TITLE
Patch for 4.5 kernel crash

### DIFF
--- a/nvidia-4.5-kernel_fix.patch
+++ b/nvidia-4.5-kernel_fix.patch
@@ -1,0 +1,26 @@
+--- a/kernel/nvidia/nv-vm.c
++++ b/kernel/nvidia/nv-vm.c
+@@ -366,7 +366,11 @@ NV_STATUS nv_alloc_contig_pages(
+     nv_printf(NV_DBG_MEMINFO,
+             "NVRM: VM: %s: %u pages\n", __FUNCTION__, at->num_pages);
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,5,0)
++    //if (IS_VGX_HYPER())
++#else
+     if (IS_VGX_HYPER())
++#endif
+         return nv_alloc_coherent_pages(nv, at);
+ 
+     at->order = get_order(at->num_pages * PAGE_SIZE);
+@@ -440,7 +444,11 @@ void nv_free_contig_pages(
+     nv_printf(NV_DBG_MEMINFO,
+             "NVRM: VM: %s: %u pages\n", __FUNCTION__, at->num_pages);
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,5,0)
++    //if (IS_VGX_HYPER())
++#else
+     if (IS_VGX_HYPER())
++#endif
+         return nv_free_coherent_pages(at);
+ 
+     if (!NV_ALLOC_MAPPING_CACHED(at->flags))

--- a/nvidia-kmod.spec
+++ b/nvidia-kmod.spec
@@ -9,7 +9,7 @@ Name:          nvidia-kmod
 Epoch:         1
 Version:       358.16
 # Taken over by kmodtool
-Release:       1%{?dist}
+Release:       2%{?dist}
 Summary:       NVIDIA display driver kernel module
 Group:         System Environment/Kernel
 License:       Redistributable, no modification permitted
@@ -18,6 +18,7 @@ URL:           http://www.nvidia.com/
 Source11:      nvidia-kmodtool-excludekernel-filterfile
 Patch0:        nv-linux-arm.patch
 Patch1:        nv-linux-arm2.patch
+Patch2:        nvidia-4.5-kernel_fix.patch
 
 BuildRoot:     %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
@@ -45,7 +46,7 @@ tar --use-compress-program xz -xf %{_datadir}/%{name}-%{version}/%{name}-%{versi
 # patch loop
 %patch0 -p1
 %patch1 -p1
-
+%patch2 -p1
 
 for kernel_version  in %{?kernel_versions} ; do
     cp -a kernel _kmod_build_${kernel_version%%___*}
@@ -77,6 +78,9 @@ rm -rf $RPM_BUILD_ROOT
 
 
 %changelog
+* Mon May 16 2016 Leigh Scott <leigh123linux@googlemail.com> - 1:358.16-2
+- Patch for 4.5 kernel crash
+
 * Sat Nov 21 2015 Nicolas Chauvet <kwizart@gmail.com> - 1:358.16-1
 - Update to 358.16
 


### PR DESCRIPTION
The 4.5 kernel has 'CONFIG_DEBUG_VM_PGFLAGS=y' which breaks nvidia driver on boot up

https://devtalk.nvidia.com/default/topic/928352/linux/crash-with-kernel-4-5-and-4-6/

https://bugzilla.redhat.com/show_bug.cgi?id=1335173

The 4.5 kernel is in updates-testing for F23

https://bodhi.fedoraproject.org/updates/FEDORA-2016-9d91338972
