### PR TITLE
Add kernel 6.17 rc patch

### DIFF
--- a/nvidia-6.17.patch
+++ b/nvidia-6.17.patch
@@ -1,30 +1,53 @@
 diff -uNrp a/kernel/nvidia-drm/nvidia-drm-fb.c b/kernel/nvidia-drm/nvidia-drm-fb.c
---- a/kernel/nvidia-drm/nvidia-drm-fb.c	2025-07-27 08:41:16.000000000 +0200
-+++ b/kernel/nvidia-drm/nvidia-drm-fb.c	2025-08-07 12:54:31.707099903 +0200
-@@ -242,6 +242,7 @@ fail:
+--- a/kernel/nvidia-drm/nvidia-drm-fb.c
++++ b/kernel/nvidia-drm/nvidia-drm-fb.c
+@@ -33,6 +33,7 @@
+ #include "nvidia-drm-format.h"
+ 
+ #include <drm/drm_crtc_helper.h>
++#include <linux/version.h>
+ 
+ static void __nv_drm_framebuffer_free(struct nv_drm_framebuffer *nv_fb)
+ {
+@@ -242,6 +243,9 @@ fail:
  struct drm_framebuffer *nv_drm_framebuffer_create(
      struct drm_device *dev,
      struct drm_file *file,
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
 +    const struct drm_format_info *info,
++#endif
      const struct drm_mode_fb_cmd2 *cmd)
  {
      struct nv_drm_device *nv_dev = to_nv_device(dev);
-@@ -289,6 +290,7 @@ struct drm_framebuffer *nv_drm_framebuff
+@@ -289,6 +293,9 @@ struct drm_framebuffer *nv_drm_framebuffer_create(
      drm_helper_mode_fill_fb_struct(
          dev,
          &nv_fb->base,
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
 +        info,
++#endif
          cmd);
  
      /*
 diff -uNrp a/kernel/nvidia-drm/nvidia-drm-fb.h b/kernel/nvidia-drm/nvidia-drm-fb.h
---- a/kernel/nvidia-drm/nvidia-drm-fb.h	2025-07-27 08:41:14.000000000 +0200
-+++ b/kernel/nvidia-drm/nvidia-drm-fb.h	2025-08-07 12:52:26.827194261 +0200
-@@ -53,6 +53,7 @@ static inline struct nv_drm_framebuffer
+--- a/kernel/nvidia-drm/nvidia-drm-fb.h
++++ b/kernel/nvidia-drm/nvidia-drm-fb.h
+@@ -31,6 +31,8 @@
+ #include <drm/drmP.h>
+ #endif
+ 
++#include <linux/version.h>
++
+ #include <drm/drm_framebuffer.h>
+ 
+ #include "nvkms-kapi.h"
+@@ -53,6 +55,9 @@ static inline struct nv_drm_framebuffer *to_nv_framebuffer(
  struct drm_framebuffer *nv_drm_framebuffer_create(
      struct drm_device *dev,
      struct drm_file *file,
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
 +    const struct drm_format_info *info,
++#endif
      const struct drm_mode_fb_cmd2 *cmd);
  
  #endif /* NV_DRM_AVAILABLE */

--- a/nvidia-6.17.patch
+++ b/nvidia-6.17.patch
@@ -1,0 +1,30 @@
+diff -uNrp a/kernel/nvidia-drm/nvidia-drm-fb.c b/kernel/nvidia-drm/nvidia-drm-fb.c
+--- a/kernel/nvidia-drm/nvidia-drm-fb.c	2025-07-27 08:41:16.000000000 +0200
++++ b/kernel/nvidia-drm/nvidia-drm-fb.c	2025-08-07 12:54:31.707099903 +0200
+@@ -242,6 +242,7 @@ fail:
+ struct drm_framebuffer *nv_drm_framebuffer_create(
+     struct drm_device *dev,
+     struct drm_file *file,
++    const struct drm_format_info *info,
+     const struct drm_mode_fb_cmd2 *cmd)
+ {
+     struct nv_drm_device *nv_dev = to_nv_device(dev);
+@@ -289,6 +290,7 @@ struct drm_framebuffer *nv_drm_framebuff
+     drm_helper_mode_fill_fb_struct(
+         dev,
+         &nv_fb->base,
++        info,
+         cmd);
+ 
+     /*
+diff -uNrp a/kernel/nvidia-drm/nvidia-drm-fb.h b/kernel/nvidia-drm/nvidia-drm-fb.h
+--- a/kernel/nvidia-drm/nvidia-drm-fb.h	2025-07-27 08:41:14.000000000 +0200
++++ b/kernel/nvidia-drm/nvidia-drm-fb.h	2025-08-07 12:52:26.827194261 +0200
+@@ -53,6 +53,7 @@ static inline struct nv_drm_framebuffer
+ struct drm_framebuffer *nv_drm_framebuffer_create(
+     struct drm_device *dev,
+     struct drm_file *file,
++    const struct drm_format_info *info,
+     const struct drm_mode_fb_cmd2 *cmd);
+ 
+ #endif /* NV_DRM_AVAILABLE */

--- a/nvidia-kmod.spec
+++ b/nvidia-kmod.spec
@@ -20,6 +20,7 @@ URL:           https://www.nvidia.com/
 
 Source11:      nvidia-kmodtool-excludekernel-filterfile
 Patch0:        make_modeset_default.patch
+Patch1:        nvidia-6.17.patch
 
 Source100:     nvidia-kmod-noopen-checks
 Source101:     nvidia-kmod-noopen-pciids.txt
@@ -62,6 +63,7 @@ echo "Using original nvidia defaults"
 %else
 echo "Set nvidia to modeset=1"
 %patch -P0 -p1
+%patch -P1 -p1
 %endif
 
 for kernel_version  in %{?kernel_versions} ; do

--- a/nvidia-kmod.spec
+++ b/nvidia-kmod.spec
@@ -13,7 +13,7 @@ Name:          nvidia-kmod
 Epoch:         3
 Version:       580.76.05
 # Taken over by kmodtool
-Release:       1%{?dist}
+Release:       2%{?dist}
 Summary:       NVIDIA display driver kernel module
 License:       Redistributable, no modification permitted
 URL:           https://www.nvidia.com/


### PR DESCRIPTION
This allows for building on the 6.17 rc kernel.

Patch taken from https://github.com/CachyOS/CachyOS-PKGBUILDS/blob/master/nvidia/nvidia-utils/6.17.patch with a couple small changes